### PR TITLE
Add dev run script and handshake logs

### DIFF
--- a/Data/DeviceList.test.js
+++ b/Data/DeviceList.test.js
@@ -32,6 +32,7 @@ export default {
     // "mn60o1u7xv8qh8f1": { leds: [1,2,3] },
     "stmkcsykq3kheboa": { leds: [1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16], name: "Battletron Light Bar" },
     "yrg6a649fkozp1hw": { leds: [1], name: "Battletron Ball Light" },
+    "keyj3w8cmutjmwk5": { leds: [], name: "Generic LED Strip" },
     // "m2jqc9ocwnxdsgs8": { leds: [1,2,3] },
     // "8cml7rj948sagivg": { leds: [1,2,3] },
     // "hy57lewrecoee6hv": { leds: [1,2,3] },

--- a/Data/DeviceList.test.js
+++ b/Data/DeviceList.test.js
@@ -40,3 +40,50 @@ export default {
     // "cjhv8tkjk7qos3jz": { leds: [1,2,3] },
     // "xxazcsrqorqcxpui": { leds: [1,2,3] },
 }
+
+export const TestDevices = [
+    {
+        id: 'bfbe7bd231444751090bsq',
+        name: 'Leds habitación',
+        ip: '192.168.1.131',
+        key: 'dHb;IQrWT&tv?XCi',
+        version: '3.5',
+        productKey: 'keyj3w8cmutjmwk5',
+        leds: 40,
+        type: 'LED Strip',
+        enabled: true
+    },
+    {
+        id: 'bfbebb82be7220f985rawa',
+        name: 'Escritorio',
+        ip: '192.168.1.130',
+        key: 'EvKXuTB^A0(T`quq',
+        version: '3.5',
+        productKey: 'keyj3w8cmutjmwk5',
+        leds: 36,
+        type: 'LED Strip',
+        enabled: true
+    },
+    {
+        id: 'bfde5007394a05833ahsda',
+        name: 'Leds habitación 2',
+        ip: '192.168.1.133',
+        key: '81u+<zg)h)oNPVo/',
+        version: '3.5',
+        productKey: 'keyj3w8cmutjmwk5',
+        leds: 40,
+        type: 'LED Strip',
+        enabled: true
+    },
+    {
+        id: 'bfafad43febddb888apxbj',
+        name: 'Monitor',
+        ip: '192.168.1.129',
+        key: 'OE4lO]Id<-ws`d;9',
+        version: '3.5',
+        productKey: 'keyj3w8cmutjmwk5',
+        leds: 72,
+        type: 'LED Strip',
+        enabled: true
+    }
+];

--- a/TuyaNegotiator.test.js
+++ b/TuyaNegotiator.test.js
@@ -51,6 +51,7 @@ export default class TuyaNegotiator extends TuyaEncryptor
     {
         if (!this.devices.hasOwnProperty(tuyaDevice.crc))
         {
+            service.log(`Adding device ${tuyaDevice.id} to negotiator`);
             if (!this.broadcastIp) this.setBroadcastIp(tuyaDevice.ip);
 
             this.devices[tuyaDevice.crc] = tuyaDevice;
@@ -133,6 +134,7 @@ export default class TuyaNegotiator extends TuyaEncryptor
 
     negotiateDevice(deviceBatchData)
     {
+        service.log('Negotiating device batch: ' + deviceBatchData.map(d => d.id).join(', '));
         // Create random nonce in hex
         const nonce = this.randomHexBytes(12);
 
@@ -184,6 +186,8 @@ export default class TuyaNegotiator extends TuyaEncryptor
         let data = new Uint8Array(packet.buffer);
         if (data.length < 64) return;
 
+        service.log('Received packet: ' + this.byteArrayToHex(data));
+
         // let byteArray = this.hexToByteArray(data);
         // Razer message:
         let message = new TuyaMessage(data);
@@ -208,6 +212,7 @@ export default class TuyaNegotiator extends TuyaEncryptor
 
     negotiateSessionKey(device, message)
     {
+        service.log(`Negotiating session key for device ${device.id}`);
         const localKeyHex = this.hexFromString(device.localKey, 16);
 
         service.log('Hexified local key ' + localKeyHex);

--- a/node_modules/@SignalRGB/udp/index.js
+++ b/node_modules/@SignalRGB/udp/index.js
@@ -1,0 +1,22 @@
+import dgram from 'dgram';
+
+export function createSocket(options = 'udp4') {
+    const socket = dgram.createSocket(options);
+
+    socket.write = function(data, ip, port) {
+        const buffer = Buffer.isBuffer(data)
+            ? data
+            : Buffer.from(data instanceof ArrayBuffer ? new Uint8Array(data) : data);
+        socket._remoteIp = ip;
+        socket._remotePort = port;
+        socket.send(buffer, 0, buffer.length, port, ip);
+    };
+
+    socket.remoteAddress = function() {
+        return { address: socket._remoteIp, port: socket._remotePort };
+    };
+
+    return socket;
+}
+
+export default { createSocket };

--- a/package.json
+++ b/package.json
@@ -1,0 +1,3 @@
+{
+  "type": "module"
+}

--- a/run.js
+++ b/run.js
@@ -1,0 +1,56 @@
+import { DiscoveryService } from './TuyaRazer.js';
+import DeviceList, { TestDevices } from './Data/DeviceList.test.js';
+
+// Simple service mock for testing
+global.service = {
+    controllers: [],
+    controllerMap: {},
+    settings: {},
+    log: console.log,
+    hasController(id) { return !!this.controllerMap[id]; },
+    getController(id) { return this.controllerMap[id]; },
+    addController(controller) {
+        this.controllerMap[controller.id] = controller;
+        this.controllers.push({ obj: controller });
+        this.log(`Controller added: ${controller.id}`);
+    },
+    removeController(controller) {
+        this.controllers = this.controllers.filter(c => c.obj !== controller);
+        delete this.controllerMap[controller.id];
+    },
+    announceController(controller) {
+        this.log(`Announce controller ${controller.id}`);
+    },
+    updateController(controller) {
+        this.log(`Update controller ${controller.id}`);
+    },
+    saveSetting(id, key, value) {
+        if (!this.settings[id]) this.settings[id] = {};
+        this.settings[id][key] = value;
+    },
+    getSetting(id, key) {
+        return this.settings[id] ? this.settings[id][key] : null;
+    }
+};
+
+const discovery = new DiscoveryService();
+discovery.Initialize();
+
+if (Array.isArray(TestDevices)) {
+    TestDevices.forEach(dev => {
+        const data = {
+            gwId: dev.id,
+            uuid: dev.id,
+            ip: dev.ip,
+            localKey: dev.key,
+            version: dev.version,
+            productKey: dev.productKey,
+            deviceType: dev.productKey,
+            enabled: dev.enabled
+        };
+        discovery.handleTuyaDiscovery(data);
+    });
+}
+
+setInterval(() => discovery.Update(), 1000);
+


### PR DESCRIPTION
## Summary
- add `run.js` script for testing the plugin locally
- include example devices in `DeviceList.test.js`
- log negotiation activity inside `TuyaNegotiator.test.js`

## Testing
- `node run.js` *(fails: Cannot find package '@SignalRGB/udp')*

------
https://chatgpt.com/codex/tasks/task_e_6846bc3bb2ac83229dcb2a1dfc7ee9ce